### PR TITLE
Remove directory import

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,4 +3,4 @@
  * Library entrypoint
  */
 
-export * as uk from "./uk";
+export * as uk from "./uk/index.js";


### PR DESCRIPTION
Technically, esmodules doesn't yet support directory imports — which means if you import this library into a project that uses modules, it throws an error. Because this is a dependency of `g-components`, a starter-kit project threw the following:

<img width="1166" alt="Screenshot 2024-01-11 at 13 57 40" src="https://github.com/Financial-Times/djd-politics-utilities/assets/3749412/0574a789-e0a6-44d8-9315-0e6bb46bf27c">

This tiny PR should fix the issue.